### PR TITLE
Add JWT auth and protect signup/unregister endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+PyJWT>=2.8.0
+passlib[bcrypt]>=1.7.4


### PR DESCRIPTION
Adds JWT-based authentication, password hashing, and `/auth/register` and `/auth/login` endpoints. Protects `/activities/{name}/signup` and `/activities/{name}/unregister` so users must authenticate and may only act on their own email. Also updates `requirements.txt`.